### PR TITLE
Update cve-2021-44228_cve-2021-45046-windows.audit

### DIFF
--- a/cve-2021-44228_cve-2021-45046/cve-2021-44228_cve-2021-45046-windows.audit
+++ b/cve-2021-44228_cve-2021-45046/cve-2021-44228_cve-2021-45046-windows.audit
@@ -85,6 +85,7 @@ $fd = @()
 'Checking:'
 Get-ChildItem -Path '@SEARCH_PATHS@' -Filter '*.?ar' -Recurse -ErrorAction SilentlyContinue | Where {$_.Extension -in '.jar','.ear','.war'} | Foreach-Object { 
  if ($_.Extension -eq '.jar' -and $_.Name -notlike '@JAR_NAME_FILTER@') {return}
+ if ($_.PSIsContainer) {'skipping folder ' + $_.Name; return }
  $z = [System.IO.Compression.ZipFile]::OpenRead($_.FullName)
  s $_.FullName $z
  $z.Dispose()


### PR DESCRIPTION
added PSIsContainer to evaluate if objects are files or directories